### PR TITLE
add a8r admin detection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ RUN apk update && \
     go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2
 WORKDIR /build
 COPY . .    
-RUN make build
+RUN export GOARCH=amd64 && export GOOS=linux && make build
+
 
 FROM alpine:3.15
 COPY --from=build-stage /build/ambassador-agent /usr/local/bin

--- a/helm/ambassador-agent/templates/ambassadorAdminRBAC.yaml
+++ b/helm/ambassador-agent/templates/ambassadorAdminRBAC.yaml
@@ -1,9 +1,16 @@
+{{ $adminNS:="ambassador" }}
+{{ if .Values.edgstack }}
+{{ if .Values.edgstack.namespace }}
 {{ if .Values.edgestack.agent.namespace }}
+{{ $adminNS = .Values.edgestack.agent.namespace }}
+{{ end }}
+{{ end }}
+{{ end }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "ambassador-agent.fullname" . }}-admin-watcher
-  namespace: {{ .Value.edgestack.agent.namespace }}
+  namespace: {{ $adminNS }}
   labels:
     app.kubernetes.io/name: {{ include "ambassador-agent.name" . }}
     {{- include "ambassador-agent.labels" . | nindent 4 }}
@@ -16,7 +23,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "ambassador-agent.fullname" . }}-admin-watcher
-  namespace: {{ .Value.edgestack.agent.namespace }}
+  namespace: {{ $adminNS }}
   labels:
     app.kubernetes.io/name: {{ include "ambassador-agent.name" . }}
     {{- include "ambassador-agent.labels" . | nindent 4 }}
@@ -28,4 +35,3 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "ambassador-agent.fullname" . }}
   namespace: {{ include "ambassador-agent.namespace" . }}
-{{ end }}

--- a/helm/ambassador-agent/templates/ambassadorAdminRBAC.yaml
+++ b/helm/ambassador-agent/templates/ambassadorAdminRBAC.yaml
@@ -1,0 +1,31 @@
+{{ if .Values.edgestack.agent.namespace }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "ambassador-agent.fullname" . }}-admin-watcher
+  namespace: {{ .Value.edgestack.agent.namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "ambassador-agent.name" . }}
+    {{- include "ambassador-agent.labels" . | nindent 4 }}
+rules:
+- apiGroups: [""]
+  resources: [ "services" ]
+  verbs: [ "watch" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "ambassador-agent.fullname" . }}-admin-watcher
+  namespace: {{ .Value.edgestack.agent.namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "ambassador-agent.name" . }}
+    {{- include "ambassador-agent.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "ambassador-agent.fullname" . }}-admin-watcher
+subjects:
+- kind: ServiceAccount
+  name: {{ include "ambassador-agent.fullname" . }}
+  namespace: {{ include "ambassador-agent.namespace" . }}
+{{ end }}

--- a/helm/ambassador-agent/templates/deployment.yaml
+++ b/helm/ambassador-agent/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: AGENT_CONFIG_RESOURCE_NAME
-              value: {{ include "ambassador-agent.fullname" . }}-agent-cloud-token
+              value: {{ include "ambassador-agent.fullname" . }}-cloud-token
             - name: RPC_CONNECTION_ADDRESS
               value: {{ .Values.rpcAddress }}
             {{- if .Values.edgestack }}
@@ -50,6 +50,10 @@ spec:
             - name: AES_SNAPSHOT_URL
               value: "http://{{ required "A value must be entered for all edgestack.agent entries" .name  }}-admin.{{ required "A value must be entered for all edgestack.agent entries" .namespace }}:{{ required "A value must be entered for all edgestack.agent entries" .snapshotPort }}/snapshot-external"
             {{- end }}
+            {{- end }}
+            {{- if .Values.edgestack.agent.namespace  }}
+            - name: AES_ADMIN_NAMESPACE
+              value: {{ .Values.edgestack.agent.namespace }}
             {{- end }}
             {{- end }}
             {{ if .Values.rbac.namespaces }}


### PR DESCRIPTION
Adds a watcher to enable/disable snapshots from the ambassador-admin service depending on its availability.
Addresses #11.