### PR TITLE
Fix URL for API Documentation

### DIFF
--- a/pkg/agent/api_docs.go
+++ b/pkg/agent/api_docs.go
@@ -251,7 +251,7 @@ func newOpenAPI(ctx context.Context, docBytes []byte, baseURL string, prefix str
 	}
 
 	// Get prefix out of first server URL. E.g. if it's
-	// http://example.com/v1, we want to to add /v1 after the Ambassador
+	// http://example.com/v1, we want to add /v1 after the Ambassador
 	// prefix.
 	existingPrefix := ""
 	if doc.Servers != nil && doc.Servers[0] != nil {
@@ -269,7 +269,12 @@ func newOpenAPI(ctx context.Context, docBytes []byte, baseURL string, prefix str
 		dlog.Debugf(ctx, "could not parse URL %q", baseURL)
 	} else {
 		if prefix != "" {
-			if existingPrefix != "" && keepExistingPrefix {
+
+			if existingPrefix != "" &&
+				keepExistingPrefix &&
+				strings.TrimRight(prefix, "/") != strings.TrimRight(existingPrefix, "/") &&
+				!strings.HasSuffix(strings.TrimRight(prefix, "/"), strings.TrimRight(existingPrefix, "/")) {
+
 				base.Path = path.Join(base.Path, prefix, existingPrefix)
 			} else {
 				base.Path = path.Join(base.Path, prefix)

--- a/pkg/agent/api_docs.go
+++ b/pkg/agent/api_docs.go
@@ -269,11 +269,13 @@ func newOpenAPI(ctx context.Context, docBytes []byte, baseURL string, prefix str
 		dlog.Debugf(ctx, "could not parse URL %q", baseURL)
 	} else {
 		if prefix != "" {
+			prefixTrim := strings.TrimRight(prefix, "/")
+			existingPrefixTrim := strings.TrimRight(existingPrefix, "/")
 
 			if existingPrefix != "" &&
 				keepExistingPrefix &&
-				strings.TrimRight(prefix, "/") != strings.TrimRight(existingPrefix, "/") &&
-				!strings.HasSuffix(strings.TrimRight(prefix, "/"), strings.TrimRight(existingPrefix, "/")) {
+				prefixTrim != existingPrefixTrim &&
+				!strings.HasSuffix(prefixTrim, existingPrefixTrim) {
 
 				base.Path = path.Join(base.Path, prefix, existingPrefix)
 			} else {

--- a/pkg/agent/api_docs_test.go
+++ b/pkg/agent/api_docs_test.go
@@ -187,6 +187,276 @@ func TestAPIDocsStore(t *testing.T) {
 				Data: []byte(`{"components":{},"info":{"title":"Sample API","version":"0.0"},"openapi":"3.0.0","paths":{},"servers":[{"url":""}]}`),
 			}},
 		},
+		{
+			name: "will handle prefix if it's already declared in the API Docs",
+			mappings: []*amb.Mapping{
+				{
+					TypeMeta: kates.TypeMeta{
+						Kind: "Mapping",
+					},
+					Spec: amb.MappingSpec{
+						Prefix:  "/prefix/",
+						Rewrite: agent.StrToPointer("/prefix/"),
+						Service: "some-svc:8080",
+						Docs: &amb.DocsInfo{
+							DisplayName: "docs-display-name",
+							Path:        "/docs-location",
+						},
+						DeprecatedHost: "mapping-host",
+					},
+					ObjectMeta: kates.ObjectMeta{
+						Name:      "some-endpoint",
+						Namespace: "default",
+					},
+				},
+			},
+
+			rawJSONDocsContent: `{"openapi":"3.0.0", "info":{"title": "Sample API", "version":"0.0"}, "paths":{}, "servers":[{"url":"http://mapping-host/prefix/"}]}`,
+
+			expectedRequestURL:     "http://some-svc.default:8080/prefix/docs-location",
+			expectedRequestHost:    "mapping-host",
+			expectedRequestHeaders: []agent.Header{},
+			expectedSOTW: []*snapshotTypes.APIDoc{{
+				TypeMeta: &kates.TypeMeta{
+					Kind:       "OpenAPI",
+					APIVersion: "v3",
+				},
+				Metadata: &kates.ObjectMeta{
+					Name: "docs-display-name",
+				},
+				TargetRef: &kates.ObjectReference{
+					Kind:      "Mapping",
+					Name:      "some-endpoint",
+					Namespace: "default",
+				},
+				Data: []byte(`{"components":{},"info":{"title":"Sample API","version":"0.0"},"openapi":"3.0.0","paths":{},"servers":[{"url":"mapping-host/prefix"}]}`),
+			}},
+		},
+		{
+			name: "will handle prefix (no trailing slash) if it's already declared in the API Docs",
+			mappings: []*amb.Mapping{
+				{
+					TypeMeta: kates.TypeMeta{
+						Kind: "Mapping",
+					},
+					Spec: amb.MappingSpec{
+						Prefix:  "/prefix",
+						Rewrite: agent.StrToPointer("/prefix/"),
+						Service: "some-svc:8080",
+						Docs: &amb.DocsInfo{
+							DisplayName: "docs-display-name",
+							Path:        "/docs-location",
+						},
+						DeprecatedHost: "mapping-host",
+					},
+					ObjectMeta: kates.ObjectMeta{
+						Name:      "some-endpoint",
+						Namespace: "default",
+					},
+				},
+			},
+
+			rawJSONDocsContent: `{"openapi":"3.0.0", "info":{"title": "Sample API", "version":"0.0"}, "paths":{}, "servers":[{"url":"http://mapping-host/prefix/"}]}`,
+
+			expectedRequestURL:     "http://some-svc.default:8080/prefix/docs-location",
+			expectedRequestHost:    "mapping-host",
+			expectedRequestHeaders: []agent.Header{},
+			expectedSOTW: []*snapshotTypes.APIDoc{{
+				TypeMeta: &kates.TypeMeta{
+					Kind:       "OpenAPI",
+					APIVersion: "v3",
+				},
+				Metadata: &kates.ObjectMeta{
+					Name: "docs-display-name",
+				},
+				TargetRef: &kates.ObjectReference{
+					Kind:      "Mapping",
+					Name:      "some-endpoint",
+					Namespace: "default",
+				},
+				Data: []byte(`{"components":{},"info":{"title":"Sample API","version":"0.0"},"openapi":"3.0.0","paths":{},"servers":[{"url":"mapping-host/prefix"}]}`),
+			}},
+		},
+		{
+			name: "will handle prefix if it's already declared in the API Docs - BasePath with no trailing slash",
+			mappings: []*amb.Mapping{
+				{
+					TypeMeta: kates.TypeMeta{
+						Kind: "Mapping",
+					},
+					Spec: amb.MappingSpec{
+						Prefix:  "/prefix/",
+						Rewrite: agent.StrToPointer("/prefix/"),
+						Service: "some-svc:8080",
+						Docs: &amb.DocsInfo{
+							DisplayName: "docs-display-name",
+							Path:        "/docs-location",
+						},
+						DeprecatedHost: "mapping-host",
+					},
+					ObjectMeta: kates.ObjectMeta{
+						Name:      "some-endpoint",
+						Namespace: "default",
+					},
+				},
+			},
+
+			rawJSONDocsContent: `{"openapi":"3.0.0", "info":{"title": "Sample API", "version":"0.0"}, "paths":{}, "servers":[{"url":"http://mapping-host/prefix"}]}`,
+
+			expectedRequestURL:     "http://some-svc.default:8080/prefix/docs-location",
+			expectedRequestHost:    "mapping-host",
+			expectedRequestHeaders: []agent.Header{},
+			expectedSOTW: []*snapshotTypes.APIDoc{{
+				TypeMeta: &kates.TypeMeta{
+					Kind:       "OpenAPI",
+					APIVersion: "v3",
+				},
+				Metadata: &kates.ObjectMeta{
+					Name: "docs-display-name",
+				},
+				TargetRef: &kates.ObjectReference{
+					Kind:      "Mapping",
+					Name:      "some-endpoint",
+					Namespace: "default",
+				},
+				Data: []byte(`{"components":{},"info":{"title":"Sample API","version":"0.0"},"openapi":"3.0.0","paths":{},"servers":[{"url":"mapping-host/prefix"}]}`),
+			}},
+		},
+		{
+			name: "will handle prefix if it's already declared in the API Docs and include the rewrite",
+			mappings: []*amb.Mapping{
+				{
+					TypeMeta: kates.TypeMeta{
+						Kind: "Mapping",
+					},
+					Spec: amb.MappingSpec{
+						Prefix:  "/subpath/prefix/",
+						Rewrite: agent.StrToPointer("/prefix/"),
+						Service: "some-svc:8080",
+						Docs: &amb.DocsInfo{
+							DisplayName: "docs-display-name",
+							Path:        "/docs-location",
+						},
+						DeprecatedHost: "mapping-host",
+					},
+					ObjectMeta: kates.ObjectMeta{
+						Name:      "some-endpoint",
+						Namespace: "default",
+					},
+				},
+			},
+
+			rawJSONDocsContent: `{"openapi":"3.0.0", "info":{"title": "Sample API", "version":"0.0"}, "paths":{}, "servers":[{"url":"http://mapping-host/prefix/"}]}`,
+
+			expectedRequestURL:     "http://some-svc.default:8080/prefix/docs-location",
+			expectedRequestHost:    "mapping-host",
+			expectedRequestHeaders: []agent.Header{},
+			expectedSOTW: []*snapshotTypes.APIDoc{{
+				TypeMeta: &kates.TypeMeta{
+					Kind:       "OpenAPI",
+					APIVersion: "v3",
+				},
+				Metadata: &kates.ObjectMeta{
+					Name: "docs-display-name",
+				},
+				TargetRef: &kates.ObjectReference{
+					Kind:      "Mapping",
+					Name:      "some-endpoint",
+					Namespace: "default",
+				},
+				Data: []byte(`{"components":{},"info":{"title":"Sample API","version":"0.0"},"openapi":"3.0.0","paths":{},"servers":[{"url":"mapping-host/subpath/prefix"}]}`),
+			}},
+		},
+		{
+			name: "will concatenate prefix and rewrite",
+			mappings: []*amb.Mapping{
+				{
+					TypeMeta: kates.TypeMeta{
+						Kind: "Mapping",
+					},
+					Spec: amb.MappingSpec{
+						Prefix:  "/prefix1/",
+						Rewrite: agent.StrToPointer("/prefix/"),
+						Service: "some-svc:8080",
+						Docs: &amb.DocsInfo{
+							DisplayName: "docs-display-name",
+							Path:        "/docs-location",
+						},
+						DeprecatedHost: "mapping-host",
+					},
+					ObjectMeta: kates.ObjectMeta{
+						Name:      "some-endpoint",
+						Namespace: "default",
+					},
+				},
+			},
+
+			rawJSONDocsContent: `{"openapi":"3.0.0", "info":{"title": "Sample API", "version":"0.0"}, "paths":{}, "servers":[{"url":"http://mapping-host/prefix"}]}`,
+
+			expectedRequestURL:     "http://some-svc.default:8080/prefix/docs-location",
+			expectedRequestHost:    "mapping-host",
+			expectedRequestHeaders: []agent.Header{},
+			expectedSOTW: []*snapshotTypes.APIDoc{{
+				TypeMeta: &kates.TypeMeta{
+					Kind:       "OpenAPI",
+					APIVersion: "v3",
+				},
+				Metadata: &kates.ObjectMeta{
+					Name: "docs-display-name",
+				},
+				TargetRef: &kates.ObjectReference{
+					Kind:      "Mapping",
+					Name:      "some-endpoint",
+					Namespace: "default",
+				},
+				Data: []byte(`{"components":{},"info":{"title":"Sample API","version":"0.0"},"openapi":"3.0.0","paths":{},"servers":[{"url":"mapping-host/prefix1/prefix"}]}`),
+			}},
+		},
+		{
+			name: "will handle prefix if it's already declared in the API Docs and include the rewrite",
+			mappings: []*amb.Mapping{
+				{
+					TypeMeta: kates.TypeMeta{
+						Kind: "Mapping",
+					},
+					Spec: amb.MappingSpec{
+						Prefix:  "/whatever/",
+						Rewrite: agent.StrToPointer("/subpath/prefix/"),
+						Service: "some-svc:8080",
+						Docs: &amb.DocsInfo{
+							DisplayName: "docs-display-name",
+							Path:        "/docs-location",
+						},
+						DeprecatedHost: "mapping-host",
+					},
+					ObjectMeta: kates.ObjectMeta{
+						Name:      "some-endpoint",
+						Namespace: "default",
+					},
+				},
+			},
+
+			rawJSONDocsContent: `{"openapi":"3.0.0", "info":{"title": "Sample API", "version":"0.0"}, "paths":{}, "servers":[{"url":"http://mapping-host/subpath/prefix"}]}`,
+
+			expectedRequestURL:     "http://some-svc.default:8080/subpath/prefix/docs-location",
+			expectedRequestHost:    "mapping-host",
+			expectedRequestHeaders: []agent.Header{},
+			expectedSOTW: []*snapshotTypes.APIDoc{{
+				TypeMeta: &kates.TypeMeta{
+					Kind:       "OpenAPI",
+					APIVersion: "v3",
+				},
+				Metadata: &kates.ObjectMeta{
+					Name: "docs-display-name",
+				},
+				TargetRef: &kates.ObjectReference{
+					Kind:      "Mapping",
+					Name:      "some-endpoint",
+					Namespace: "default",
+				},
+				Data: []byte(`{"components":{},"info":{"title":"Sample API","version":"0.0"},"openapi":"3.0.0","paths":{},"servers":[{"url":"mapping-host/whatever/subpath/prefix"}]}`),
+			}},
+		},
 	}
 	for _, c := range cases {
 		c := c

--- a/pkg/agent/api_docs_test.go
+++ b/pkg/agent/api_docs_test.go
@@ -412,51 +412,6 @@ func TestAPIDocsStore(t *testing.T) {
 				Data: []byte(`{"components":{},"info":{"title":"Sample API","version":"0.0"},"openapi":"3.0.0","paths":{},"servers":[{"url":"mapping-host/prefix1/prefix"}]}`),
 			}},
 		},
-		{
-			name: "will handle prefix if it's already declared in the API Docs and include the rewrite",
-			mappings: []*amb.Mapping{
-				{
-					TypeMeta: kates.TypeMeta{
-						Kind: "Mapping",
-					},
-					Spec: amb.MappingSpec{
-						Prefix:  "/whatever/",
-						Rewrite: agent.StrToPointer("/subpath/prefix/"),
-						Service: "some-svc:8080",
-						Docs: &amb.DocsInfo{
-							DisplayName: "docs-display-name",
-							Path:        "/docs-location",
-						},
-						DeprecatedHost: "mapping-host",
-					},
-					ObjectMeta: kates.ObjectMeta{
-						Name:      "some-endpoint",
-						Namespace: "default",
-					},
-				},
-			},
-
-			rawJSONDocsContent: `{"openapi":"3.0.0", "info":{"title": "Sample API", "version":"0.0"}, "paths":{}, "servers":[{"url":"http://mapping-host/subpath/prefix"}]}`,
-
-			expectedRequestURL:     "http://some-svc.default:8080/subpath/prefix/docs-location",
-			expectedRequestHost:    "mapping-host",
-			expectedRequestHeaders: []agent.Header{},
-			expectedSOTW: []*snapshotTypes.APIDoc{{
-				TypeMeta: &kates.TypeMeta{
-					Kind:       "OpenAPI",
-					APIVersion: "v3",
-				},
-				Metadata: &kates.ObjectMeta{
-					Name: "docs-display-name",
-				},
-				TargetRef: &kates.ObjectReference{
-					Kind:      "Mapping",
-					Name:      "some-endpoint",
-					Namespace: "default",
-				},
-				Data: []byte(`{"components":{},"info":{"title":"Sample API","version":"0.0"},"openapi":"3.0.0","paths":{},"servers":[{"url":"mapping-host/whatever/subpath/prefix"}]}`),
-			}},
-		},
 	}
 	for _, c := range cases {
 		c := c


### PR DESCRIPTION
## Description
Emissary automatically adds the prefixes from the mappings to the swagger APIs on the fly. The issue with that is that sometimes, the swagger contract already contains a base path.
As a solution, we should also read the rewrite field from the mapping, and avoid adding the prefix if it matches the rewrite.

## Related Issues
emissary-ingress/emissary #4360 

I originally opened this [PR](https://github.com/emissary-ingress/emissary/pull/4380) in the emissary repo. But as discussed with @LanceEa, I'm landing it in the new repo. It can wait the next release.