### PR TITLE
filter secrets/configmaps by suffix

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -338,7 +338,7 @@ func (a *Agent) setAPIKeyConfigFrom(ctx context.Context, secrets []*kates.Secret
 		if (secret.GetName() == a.agentCloudResourceConfigName || strings.HasSuffix(secret.GetName(), cloudConnectTokenDefaultSuffix)) && secret.GetNamespace() == a.agentNamespace {
 			connTokenBytes, ok := secret.Data[cloudConnectTokenKey]
 			connToken := string(connTokenBytes)
-			dlog.Infof(ctx, "Setting cloud connect token from secret")
+			dlog.Infof(ctx, "Setting cloud connect token from secret: %s", secret.GetName())
 			a.ambassadorAPIKey = getAPIKeyValue(connToken, ok)
 			resetComm(a.ambassadorAPIKey, prevKey, a)
 			return
@@ -352,7 +352,7 @@ func (a *Agent) setAPIKeyConfigFrom(ctx context.Context, secrets []*kates.Secret
 		if (cm.GetName() == a.agentCloudResourceConfigName || strings.HasSuffix(cm.GetName(), cloudConnectTokenDefaultSuffix)) && cm.GetNamespace() == a.agentNamespace {
 			connTokenBytes, ok := cm.Data[cloudConnectTokenKey]
 			connToken := string(connTokenBytes)
-			dlog.Infof(ctx, "Setting cloud connect token from configmap")
+			dlog.Infof(ctx, "Setting cloud connect token from configmap: %s", cm.GetName())
 			a.ambassadorAPIKey = getAPIKeyValue(connToken, ok)
 			resetComm(a.ambassadorAPIKey, prevKey, a)
 			return

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -35,8 +35,8 @@ import (
 
 const defaultMinReportPeriod = 30 * time.Second
 const (
-	cloudConnectTokenKey             = "CLOUD_CONNECT_TOKEN"
-	cloudConnectTokenDefaultResource = "ambassador-agent-cloud-token"
+	cloudConnectTokenKey           = "CLOUD_CONNECT_TOKEN"
+	cloudConnectTokenDefaultSuffix = "agent-cloud-token"
 )
 
 type Comm interface {
@@ -205,7 +205,7 @@ func NewAgent(
 		ambassadorAPIKeyEnvVarValue:  os.Getenv(cloudConnectTokenKey),
 		connAddress:                  os.Getenv("RPC_CONNECTION_ADDRESS"),
 		agentNamespace:               agentNamespace,
-		agentCloudResourceConfigName: getEnvWithDefault("AGENT_CONFIG_RESOURCE_NAME", cloudConnectTokenDefaultResource),
+		agentCloudResourceConfigName: os.Getenv("AGENT_CONFIG_RESOURCE_NAME"),
 		directiveHandler:             directiveHandler,
 		reportRunning:                atomicBool{value: false},
 		agentWatchFieldSelector:      getEnvWithDefault("AGENT_WATCH_FIELD_SELECTOR", "metadata.namespace!=kube-system"),
@@ -335,7 +335,7 @@ func (a *Agent) setAPIKeyConfigFrom(ctx context.Context, secrets []*kates.Secret
 	// there _should_ only be one secret here, but we're going to loop and check that the object
 	// meta matches what we expect
 	for _, secret := range secrets {
-		if (secret.GetName() == a.agentCloudResourceConfigName || secret.GetName() == cloudConnectTokenDefaultResource) && secret.GetNamespace() == a.agentNamespace {
+		if (secret.GetName() == a.agentCloudResourceConfigName || strings.HasSuffix(secret.GetName(), cloudConnectTokenDefaultSuffix)) && secret.GetNamespace() == a.agentNamespace {
 			connTokenBytes, ok := secret.Data[cloudConnectTokenKey]
 			connToken := string(connTokenBytes)
 			dlog.Infof(ctx, "Setting cloud connect token from secret")
@@ -349,7 +349,7 @@ func (a *Agent) setAPIKeyConfigFrom(ctx context.Context, secrets []*kates.Secret
 	// there _should_ only be one config here, but we're going to loop and check that the object
 	// meta matches what we expect
 	for _, cm := range cmaps {
-		if (cm.GetName() == a.agentCloudResourceConfigName || cm.GetName() == cloudConnectTokenDefaultResource) && cm.GetNamespace() == a.agentNamespace {
+		if (cm.GetName() == a.agentCloudResourceConfigName || strings.HasSuffix(cm.GetName(), cloudConnectTokenDefaultSuffix)) && cm.GetNamespace() == a.agentNamespace {
 			connTokenBytes, ok := cm.Data[cloudConnectTokenKey]
 			connToken := string(connTokenBytes)
 			dlog.Infof(ctx, "Setting cloud connect token from configmap")


### PR DESCRIPTION
Signed-off-by: njayp <nickjaypowell@gmail.com>
by default, the apikey secret/configmap will have the name `<release-name>-agent-cloud-token`. In order to find such resources, this PR has the agent detect secrets/configmaps with `agent-cloud-token` in the suffix of the name. note that the resource still has to be in the same ns as the agent