### PR TITLE
actually build cluster id from root id

### DIFF
--- a/pkg/agent/cluster.go
+++ b/pkg/agent/cluster.go
@@ -15,10 +15,11 @@ import (
 func GetClusterID(ctx context.Context, client *kubernetes.Clientset, nsName string) string {
 	clusterID := getEnvWithDefault("AMBASSADOR_CLUSTER_ID", getEnvWithDefault("AMBASSADOR_SCOUT_ID", ""))
 	if clusterID != "" {
+		dlog.Infof(ctx, "Using cluster ID from env %s", clusterID)
 		return clusterID
 	}
 
-	dlog.Infof(ctx, "Fetching cluster ID from %s namespace", nsName)
+	dlog.Infof(ctx, "Fetching cluster ID from namespace %s", nsName)
 
 	rootID := "00000000-0000-0000-0000-000000000000"
 
@@ -29,7 +30,10 @@ func GetClusterID(ctx context.Context, client *kubernetes.Clientset, nsName stri
 
 	dlog.Infof(ctx, "Using root ID %s", rootID)
 	dlog.Debugf(ctx, "Namespace looks like %+v", ns)
-	return clusterIDFromRootID(clusterID)
+	clusterID = clusterIDFromRootID(rootID)
+
+	dlog.Infof(ctx, "Using computed cluster ID %s", clusterID)
+	return clusterID
 }
 
 func clusterIDFromRootID(rootID string) string {


### PR DESCRIPTION
Signed-off-by: Raphael Reyna <raphaelreyna@protonmail.com>

## Description
Ensures that the cluster ID is computed from the root ID if not picked up from the environment.
Also adds some additional logging around cluster ID creation.

## Fill ALL sections
#### Documentation
- [ ] I updated the relevant .md documentation.
- [ ] I updated the relevant website documentation.
- [x] This PR does not require documentation updates.

#### Dependencies
- [ ] This PR contains new dependencies
- [x] This PR does not have any change in dependencies.

#### Testing
- [ ] I provided sufficient test coverage for the modified code.
- [ ] The existing tests capture the requirements for the modified code.
- [ ] The bulk of my code covered by unit tests.
- [x] I executed manual tests to validate my changes and to avoid regressions.
  
##### Testing Strategy
Manual testing with a tool that I'lll put in another pr.

