### PR TITLE
fix memory leak in metrics reporter. make apikey thread-safe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,3 +69,11 @@ itest: image-push
 .PHONY: unit-test
 unit-test:
 	go test -count=1 ./cmd/... ./pkg/...
+
+.PHONY: apply
+apply:
+	helm install ambassador-agent ./helm/ambassador-agent -n ambassador
+
+.PHONY: delete
+delete:
+	helm delete ambassador-agent -n ambassador

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -28,8 +28,8 @@ import (
 // internal k8s service
 const (
 	AdminDiagnosticsPort     = 8877
-	DefaultSnapshotURLFmt    = "http://edge-stack-admin:%d/snapshot-external"
-	DefaultDiagnosticsURLFmt = "http://edge-stack-admin:%d/ambassador/v0/diag/?json=true"
+	DefaultSnapshotURLFmt    = "http://ambassador-admin:%d/snapshot-external"
+	DefaultDiagnosticsURLFmt = "http://ambassador-admin:%d/ambassador/v0/diag/?json=true"
 
 	ExternalSnapshotPort = 8005
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -28,8 +28,8 @@ import (
 // internal k8s service
 const (
 	AdminDiagnosticsPort     = 8877
-	DefaultSnapshotURLFmt    = "http://ambassador-admin:%d/snapshot-external"
-	DefaultDiagnosticsURLFmt = "http://ambassador-admin:%d/ambassador/v0/diag/?json=true"
+	DefaultSnapshotURLFmt    = "http://edge-stack-admin:%d/snapshot-external"
+	DefaultDiagnosticsURLFmt = "http://edge-stack-admin:%d/ambassador/v0/diag/?json=true"
 
 	ExternalSnapshotPort = 8005
 
@@ -79,6 +79,10 @@ func main() {
 	grp.Go("metrics-server", func(ctx context.Context) error {
 		metricsServer := agent.NewMetricsServer(ambAgent.MetricsRelayHandler)
 		return metricsServer.Serve(ctx, metricsListener)
+	})
+
+	grp.Go("metrics-reporter", func(ctx context.Context) error {
+		return ambAgent.MetricsReporter(ctx)
 	})
 
 	// use a Go context so we can tell the leaderelection code when we

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -826,7 +826,7 @@ func (a *Agent) MetricsReporter(ctx context.Context) error {
 }
 
 func (a *Agent) ReportMetrics(ctx context.Context) {
-	// TODO make thread-safe
+	// TODO make comm thread-safe
 	if a.comm != nil && !a.reportingStopped {
 
 		a.metricsRelayMutex.Lock()
@@ -862,7 +862,6 @@ func (a *Agent) MetricsRelayHandler(
 	ctx context.Context,
 	in *envoyMetrics.StreamMetricsMessage,
 ) {
-	// TODO make thread-safe
 	if a.comm != nil && !a.reportingStopped {
 		metrics := in.GetEnvoyMetrics()
 		newMetrics := make([]*io_prometheus_client.MetricFamily, 0, len(metrics))

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -319,9 +319,9 @@ func (a *Agent) setAPIKeyConfigFrom(ctx context.Context, secrets []*kates.Secret
 	// if the key is new, reset the connection so we use a new api key (or break the connection if the api key was
 	// unset). The agent will reset the connection the next time it tries to send a report
 	maybeResetComm := func(newKey string, a *Agent) {
+		a.ambassadorAPIKeyMutex.Lock()
+		defer a.ambassadorAPIKeyMutex.Unlock()
 		if newKey != a.ambassadorAPIKey {
-			a.ambassadorAPIKeyMutex.Lock()
-			defer a.ambassadorAPIKeyMutex.Unlock()
 			a.ambassadorAPIKey = newKey
 			a.ClearComm()
 		}

--- a/pkg/agent/agent_metrics_test.go
+++ b/pkg/agent/agent_metrics_test.go
@@ -64,14 +64,14 @@ func TestMetricsRelayHandler(t *testing.T) {
 				IP: net.ParseIP("192.168.0.1"),
 			},
 		})
-		stubbedAgent.aggregatedMetrics["192.168.0.1"] = []*io_prometheus_client.MetricFamily{acceptedMetric}
 
 		//when
+		// store acceptedMetric and reject ignoredMetric
 		stubbedAgent.MetricsRelayHandler(ctx, &envoyMetrics.StreamMetricsMessage{
-			Identifier: nil,
-			// ignored since time to report.
+			Identifier:   nil,
 			EnvoyMetrics: []*io_prometheus_client.MetricFamily{ignoredMetric, acceptedMetric},
 		})
+		// report
 		stubbedAgent.ReportMetrics(ctx)
 
 		//then


### PR DESCRIPTION
Signed-off-by: njayp <nickjaypowell@gmail.com>
Fixed the memory leak. Note that `comm != nil` is not thread-safe, this will be addressed in a future PR