### PR TITLE
fix default watched ns

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ unit-test:
 
 .PHONY: apply
 apply: push-image
-	helm install ambassador-agent ./helm/ambassador-agent --set image.fullImageOverride=$(IMAGE) --set loglevel=debug --set cloudConnectToken=$(APIKEY)
+	helm install ambassador-agent ./helm/ambassador-agent --set image.fullImageOverride=$(IMAGE) --set logLevel=DEBUG --set cloudConnectToken=$(APIKEY)
 
 .PHONY: delete
 delete:

--- a/Makefile
+++ b/Makefile
@@ -129,8 +129,8 @@ unit-test:
 
 .PHONY: apply
 apply: push-image
-	helm install ambassador-agent ./helm/ambassador-agent -n ambassador --set image.fullImageOverride=$(IMAGE) --set cloudConnectToken=$(APIKEY)
+	helm install ambassador-agent ./helm/ambassador-agent --set image.fullImageOverride=$(IMAGE) --set loglevel=debug --set cloudConnectToken=$(APIKEY)
 
 .PHONY: delete
 delete:
-	helm delete ambassador-agent -n ambassador
+	helm delete ambassador-agent

--- a/Makefile
+++ b/Makefile
@@ -128,8 +128,8 @@ unit-test:
 	go test -count=1 ./cmd/... ./pkg/...
 
 .PHONY: apply
-apply:
-	helm install ambassador-agent ./helm/ambassador-agent -n ambassador --set image.pullPolicy=Always
+apply: push-image
+	helm install ambassador-agent ./helm/ambassador-agent -n ambassador --set image.fullImageOverride=$(IMAGE) --set cloudConnectToken=$(APIKEY)
 
 .PHONY: delete
 delete:

--- a/helm/ambassador-agent/values.yaml
+++ b/helm/ambassador-agent/values.yaml
@@ -21,10 +21,12 @@ serviceAccount:
 
 podAnnotations: {}
 
-podSecurityContext: {}
+podSecurityContext:
+  {}
   # fsGroup: 2000
 
-securityContext: {}
+securityContext:
+  {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -35,7 +37,8 @@ securityContext: {}
 service:
   type: ClusterIP
 
-resources: {}
+resources:
+  {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -66,7 +69,7 @@ progressDeadline: 0
 
 cloudConnectToken: ""
 
-logLevel: "debug"
+logLevel: "info"
 docker:
   useImagePullSecret: false
   imagePullSecretName: ""

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -525,7 +525,7 @@ func (a *Agent) watch( //nolint:gocognit,cyclop // TODO: Refactor this function
 			} else {
 				if a.clusterId == "" {
 					ns := "default"
-					if len(a.NamespacesToWatch) > 0 && a.NamespacesToWatch[0] != "" {
+					if len(a.NamespacesToWatch) > 0 {
 						ns = a.AgentNamespace
 					}
 					a.clusterId = a.getClusterID(ctx, ns) // get cluster id for ambMeta

--- a/pkg/agent/watchers/core_watchers.go
+++ b/pkg/agent/watchers/core_watchers.go
@@ -31,7 +31,7 @@ func NewCoreWatchers(ctx context.Context, namespaces []string, om ObjectModifier
 		L: &sync.Mutex{},
 	}
 
-	// if there are no default namespaces to watch, the watchers need to set thier namespace to "",
+	// if there are no default namespaces to watch, the watchers need to set their namespace to "",
 	// which will set them to watch the whole cluster
 	if len(namespaces) == 0 {
 		namespaces = append(namespaces, "")

--- a/pkg/agent/watchers/core_watchers.go
+++ b/pkg/agent/watchers/core_watchers.go
@@ -31,8 +31,8 @@ func NewCoreWatchers(ctx context.Context, namespaces []string, om ObjectModifier
 		L: &sync.Mutex{},
 	}
 
-	// if there are no namespaces to watch, the watchers need to set their namespace to "",
-	// which will set them to watch the whole cluster
+	// if there are no namespaces to watch, create one watcher with namespace "",
+	// which will watch the whole cluster
 	if len(namespaces) == 0 {
 		namespaces = append(namespaces, "")
 	}

--- a/pkg/agent/watchers/core_watchers.go
+++ b/pkg/agent/watchers/core_watchers.go
@@ -31,7 +31,7 @@ func NewCoreWatchers(ctx context.Context, namespaces []string, om ObjectModifier
 		L: &sync.Mutex{},
 	}
 
-	// if there are no default namespaces to watch, the watchers need to set their namespace to "",
+	// if there are no namespaces to watch, the watchers need to set their namespace to "",
 	// which will set them to watch the whole cluster
 	if len(namespaces) == 0 {
 		namespaces = append(namespaces, "")

--- a/pkg/agent/watchers/fallback_watchers.go
+++ b/pkg/agent/watchers/fallback_watchers.go
@@ -26,7 +26,7 @@ func NewFallbackWatcher(ctx context.Context, namespaces []string, om ObjectModif
 		L: &sync.Mutex{},
 	}
 
-	// if there are no default namespaces to watch, the watchers need to set thier namespace to "",
+	// if there are no default namespaces to watch, the watchers need to set their namespace to "",
 	// which will set them to watch the whole cluster
 	if len(namespaces) == 0 {
 		namespaces = append(namespaces, "")

--- a/pkg/agent/watchers/fallback_watchers.go
+++ b/pkg/agent/watchers/fallback_watchers.go
@@ -26,7 +26,7 @@ func NewFallbackWatcher(ctx context.Context, namespaces []string, om ObjectModif
 		L: &sync.Mutex{},
 	}
 
-	// if there are no default namespaces to watch, the watchers need to set their namespace to "",
+	// if there are no namespaces to watch, the watchers need to set their namespace to "",
 	// which will set them to watch the whole cluster
 	if len(namespaces) == 0 {
 		namespaces = append(namespaces, "")

--- a/pkg/agent/watchers/fallback_watchers.go
+++ b/pkg/agent/watchers/fallback_watchers.go
@@ -26,6 +26,12 @@ func NewFallbackWatcher(ctx context.Context, namespaces []string, om ObjectModif
 		L: &sync.Mutex{},
 	}
 
+	// if there are no default namespaces to watch, the watchers need to set thier namespace to "",
+	// which will set them to watch the whole cluster
+	if len(namespaces) == 0 {
+		namespaces = append(namespaces, "")
+	}
+
 	// TODO equals func to prevent over-broadcasting
 	siWatcher := &FallbackWatchers{
 		serviceWatchers: k8sapi.NewWatcherGroup[*core.Service](),

--- a/pkg/agent/watchers/fallback_watchers.go
+++ b/pkg/agent/watchers/fallback_watchers.go
@@ -26,8 +26,8 @@ func NewFallbackWatcher(ctx context.Context, namespaces []string, om ObjectModif
 		L: &sync.Mutex{},
 	}
 
-	// if there are no namespaces to watch, the watchers need to set their namespace to "",
-	// which will set them to watch the whole cluster
+	// if there are no namespaces to watch, create one watcher with namespace "",
+	// which will watch the whole cluster
 	if len(namespaces) == 0 {
 		namespaces = append(namespaces, "")
 	}


### PR DESCRIPTION
Signed-off-by: njayp <nickjaypowell@gmail.com>

## Description
When the env vars were reworked so that they were read with build tags, the default for `NAMESPACES_TO_WATCH` changed from [""] to []. The main watchers were adjusted accordingly, but the fallback watchers were not. Fixed