### PR TITLE
set `metricsReportRunning` to true while reporter is running

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -713,7 +713,7 @@ func (a *Agent) ReportMetrics(ctx context.Context) {
 		return
 	}
 	dlog.Debugf(ctx, "Relaying %d metric(s)", relayedMetricCount)
-
+	a.metricsReportRunning.Store(true)
 	go a.reportMetrics(ctx, outMessage, a.MinReportPeriod, a.AmbassadorAPIKey) // minReportPeriod is the one set for snapshots
 }
 


### PR DESCRIPTION
Signed-off-by: njayp <nickjaypowell@gmail.com>

## Description
Fix a bug where the boolean that would delay metrics reporting was never switched on