### PR TITLE
Fix type assertion ingress

### DIFF
--- a/.github/workflows/licenses.yaml
+++ b/.github/workflows/licenses.yaml
@@ -15,7 +15,7 @@ jobs:
           ref: "${{ github.event.pull_request.head.sha }}"
       - uses: actions/setup-go@v3
         with:
-          go-version: stable
+          go-version: 1.19.5
       - name: "Generate dependency information"
         shell: bash
         run: make generate

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: stable
+          go-version: 1.19.5
       - name: Lint
         run: make lint
       - name: Run Tests

--- a/go.mod
+++ b/go.mod
@@ -97,7 +97,6 @@ require (
 	k8s.io/cli-runtime v0.26.0
 	k8s.io/client-go v0.26.0
 	k8s.io/kubectl v0.26.0
-	k8s.io/kubernetes v1.26.0
 )
 
 require (
@@ -224,6 +223,7 @@ require (
 	k8s.io/component-base v0.26.0 // indirect
 	k8s.io/klog/v2 v2.80.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 // indirect
+	k8s.io/kubernetes v1.26.0 // indirect
 	k8s.io/metrics v0.26.0 // indirect
 	k8s.io/utils v0.0.0-20221107191617-1a15be271d1d // indirect
 	oras.land/oras-go v1.2.0 // indirect

--- a/pkg/agent/watchers/ingress_watcher.go
+++ b/pkg/agent/watchers/ingress_watcher.go
@@ -2,8 +2,9 @@ package watchers
 
 import (
 	"context"
-	v1networking "k8s.io/api/networking/v1"
 	"sync"
+
+	v1networking "k8s.io/api/networking/v1"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/agent/watchers/ingress_watcher.go
+++ b/pkg/agent/watchers/ingress_watcher.go
@@ -7,7 +7,6 @@ import (
 	v1networking "k8s.io/api/networking/v1"
 
 	"github.com/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
 	extv1beta1 "k8s.io/api/extensions/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,7 +44,7 @@ func (n *networkWatcher) convertStatus(ing *v1networking.Ingress) extv1beta1.Ing
 			ports[pi] = extv1beta1.IngressPortStatus{
 				Port:     port.Port,
 				Error:    port.Error,
-				Protocol: corev1.Protocol(port.Protocol),
+				Protocol: port.Protocol,
 			}
 		}
 		lbis[i] = extv1beta1.IngressLoadBalancerIngress{
@@ -73,7 +72,7 @@ func (n *networkWatcher) convertIngressBackend(backend *v1networking.IngressBack
 	return &extv1beta1.IngressBackend{
 		ServiceName: backend.Service.Name,
 		ServicePort: servicePort,
-		Resource:    (*corev1.TypedLocalObjectReference)(backend.Resource),
+		Resource:    backend.Resource,
 	}
 }
 

--- a/pkg/agent/watchers/ingress_watcher_test.go
+++ b/pkg/agent/watchers/ingress_watcher_test.go
@@ -1,0 +1,95 @@
+package watchers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	corev1 "k8s.io/api/core/v1"
+	extv1beta1 "k8s.io/api/extensions/v1beta1"
+	v1networking "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+type suiteNetworkWatcher struct {
+	suite.Suite
+
+	watcher *networkWatcher
+}
+
+func (s *suiteNetworkWatcher) BeforeTest() {
+	s.watcher = &networkWatcher{
+		watcher: nil,
+		om:      nil,
+	}
+}
+
+func (s *suiteNetworkWatcher) TestSpecConvertNoBackend() {
+	// given
+	ingress := &v1networking.Ingress{
+		Spec: v1networking.IngressSpec{
+			IngressClassName: nil,
+			DefaultBackend:   nil,
+			TLS:              nil,
+			Rules:            nil,
+		},
+		Status: v1networking.IngressStatus{
+			LoadBalancer: v1networking.IngressLoadBalancerStatus{
+				Ingress: nil,
+			},
+		},
+	}
+	// when
+	converted := s.watcher.convertSpec(ingress)
+
+	// then
+	assert.NotNil(s.T(), converted)
+	assert.Equal(s.T(), extv1beta1.IngressSpec{
+		IngressClassName: nil,
+		Backend:          nil,
+		TLS:              []extv1beta1.IngressTLS{},
+		Rules:            []extv1beta1.IngressRule{},
+	}, converted)
+}
+
+func (s *suiteNetworkWatcher) TestSpecConvertWithDefaultBackend() {
+	// given
+	ingress := &v1networking.Ingress{
+		Spec: v1networking.IngressSpec{
+			IngressClassName: nil,
+			DefaultBackend: &v1networking.IngressBackend{
+				Service: &v1networking.IngressServiceBackend{
+					Name: "http",
+					Port: v1networking.ServiceBackendPort{
+						Name:   "http",
+						Number: 80,
+					},
+				},
+			},
+		},
+		Status: v1networking.IngressStatus{
+			LoadBalancer: v1networking.IngressLoadBalancerStatus{
+				Ingress: nil,
+			},
+		},
+	}
+	// when
+	converted := s.watcher.convertSpec(ingress)
+
+	// then
+	assert.NotNil(s.T(), converted)
+	assert.Equal(s.T(), extv1beta1.IngressSpec{
+		IngressClassName: nil,
+		Backend: &extv1beta1.IngressBackend{
+			ServiceName: "http",
+			ServicePort: intstr.FromString("http"),
+			Resource:    (*corev1.TypedLocalObjectReference)(ingress.Spec.DefaultBackend.Resource),
+		},
+		TLS:   []extv1beta1.IngressTLS{},
+		Rules: []extv1beta1.IngressRule{},
+	}, converted)
+}
+
+func TestSuiteNetworkWatcher(t *testing.T) {
+	suite.Run(t, new(suiteNetworkWatcher))
+}

--- a/pkg/agent/watchers/ingress_watcher_test.go
+++ b/pkg/agent/watchers/ingress_watcher_test.go
@@ -51,7 +51,7 @@ func (s *suiteNetworkWatcher) TestSpecConvertNoBackend() {
 	}, converted)
 }
 
-func (s *suiteNetworkWatcher) TestSpecConvertWithDefaultBackend() {
+func (s *suiteNetworkWatcher) TestSpecConvertWithDefaultBackendAndRules() {
 	// given
 	ingress := &v1networking.Ingress{
 		Spec: v1networking.IngressSpec{
@@ -63,6 +63,46 @@ func (s *suiteNetworkWatcher) TestSpecConvertWithDefaultBackend() {
 						Name:   "http",
 						Number: 80,
 					},
+				},
+			},
+			Rules: []v1networking.IngressRule{{
+				Host: "www.example.com",
+				IngressRuleValue: v1networking.IngressRuleValue{
+					HTTP: &v1networking.HTTPIngressRuleValue{
+						Paths: []v1networking.HTTPIngressPath{
+							{
+								Path:     "/apis",
+								PathType: nil,
+								Backend: v1networking.IngressBackend{
+									Service: &v1networking.IngressServiceBackend{
+										Name: "api",
+										Port: v1networking.ServiceBackendPort{
+											Name:   "http",
+											Number: 80,
+										},
+									},
+								},
+							},
+							{
+								Path:     "/grpc",
+								PathType: nil,
+								Backend: v1networking.IngressBackend{
+									Service: &v1networking.IngressServiceBackend{
+										Name: "grpc",
+										Port: v1networking.ServiceBackendPort{
+											Number: 8080,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}},
+			TLS: []v1networking.IngressTLS{
+				{
+					Hosts:      []string{"www.example.com"},
+					SecretName: "my-certificate",
 				},
 			},
 		},
@@ -84,8 +124,45 @@ func (s *suiteNetworkWatcher) TestSpecConvertWithDefaultBackend() {
 			ServicePort: intstr.FromString("http"),
 			Resource:    ingress.Spec.DefaultBackend.Resource,
 		},
-		TLS:   []extv1beta1.IngressTLS{},
-		Rules: []extv1beta1.IngressRule{},
+		TLS: []extv1beta1.IngressTLS{
+			{
+				Hosts:      []string{"www.example.com"},
+				SecretName: "my-certificate",
+			},
+		},
+		Rules: []extv1beta1.IngressRule{{
+			Host: "www.example.com",
+			IngressRuleValue: extv1beta1.IngressRuleValue{
+				HTTP: &extv1beta1.HTTPIngressRuleValue{
+					Paths: []extv1beta1.HTTPIngressPath{
+						{
+							Path: "/apis",
+							Backend: extv1beta1.IngressBackend{
+								ServiceName: "api",
+								ServicePort: intstr.IntOrString{
+									Type:   intstr.String,
+									IntVal: 0,
+									StrVal: "http",
+								},
+								Resource: nil,
+							},
+						},
+						{
+							Path: "/grpc",
+							Backend: extv1beta1.IngressBackend{
+								ServiceName: "grpc",
+								ServicePort: intstr.IntOrString{
+									Type:   intstr.Int,
+									IntVal: 8080,
+									StrVal: "",
+								},
+								Resource: nil,
+							},
+						},
+					},
+				},
+			},
+		}},
 	}, converted)
 }
 

--- a/pkg/agent/watchers/ingress_watcher_test.go
+++ b/pkg/agent/watchers/ingress_watcher_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	corev1 "k8s.io/api/core/v1"
 	extv1beta1 "k8s.io/api/extensions/v1beta1"
 	v1networking "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -83,7 +82,7 @@ func (s *suiteNetworkWatcher) TestSpecConvertWithDefaultBackend() {
 		Backend: &extv1beta1.IngressBackend{
 			ServiceName: "http",
 			ServicePort: intstr.FromString("http"),
-			Resource:    (*corev1.TypedLocalObjectReference)(ingress.Spec.DefaultBackend.Resource),
+			Resource:    ingress.Spec.DefaultBackend.Resource,
 		},
 		TLS:   []extv1beta1.IngressTLS{},
 		Rules: []extv1beta1.IngressRule{},


### PR DESCRIPTION
## Description

One of our clients reported having this error in the ambassador agent:

```cli
time="2023-02-01T09:35:19Z" level=info msg="ambassador-agent v1.0.8"
time="2023-02-01T09:35:19Z" level=info msg="Using cluster domain \"cluster.local\""
time="2023-02-01T09:35:19Z" level=info msg="metrics service listening on :8080"
time="2023-02-01T09:35:19Z" level=info msg="Will lease with id ***" THREAD=/lease-lock-watch
I0201 09:35:19.133258       1 leaderelection.go:248] attempting to acquire leader lease ambassador/ambassador-agent-lease-lock...
time="2023-02-01T09:35:19Z" level=info msg="a different agent acquired the lease-lock: ***" THREAD=/lease-lock-watch
I0201 09:36:28.684501       1 leaderelection.go:258] successfully acquired lease ambassador/ambassador-agent-lease-lock
time="2023-02-01T09:36:28Z" level=info msg="Lease-lock acquired, watching cluster" THREAD=/lease-lock-watch
time="2023-02-01T09:36:28Z" level=info msg="Agent is running..." THREAD=/lease-lock-watch
time="2023-02-01T09:36:28Z" level=info msg="Setting cloud connect token from configmap: traffic-manager-agent-cloud-token" THREAD=/lease-lock-watch
time="2023-02-01T09:36:30Z" level=info msg="ambassador-admin not detected, creating own snapshots." THREAD=/lease-lock-watch
time="2023-02-01T09:36:31Z" level=info msg="Beginning to watch and report resources to ambassador cloud" THREAD=/lease-lock-watch
time="2023-02-01T09:36:31Z" level=info msg="Setting cloud connect token from configmap: traffic-manager-agent-cloud-token" THREAD=/lease-lock-watch
time="2023-02-01T09:36:31Z" level=info msg="Fetching cluster ID from namespace default" THREAD=/lease-lock-watch
time="2023-02-01T09:36:31Z" level=info msg="Using root ID ***" THREAD=/lease-lock-watch
time="2023-02-01T09:36:31Z" level=info msg="Using computed cluster ID ***" THREAD=/lease-lock-watch
panic: interface conversion: interface {} is *v1.Ingress, not *networking.Ingress

goroutine 41 [running]:
github.com/datawire/k8sapi/pkg/k8sapi.(*Watcher[...]).List(0xc00001c630, {0x23cab20, 0xc0004ee7c0?})
	github.com/datawire/k8sapi@v0.1.2/pkg/k8sapi/watcher.go:198 +0x225
github.com/datawire/k8sapi/pkg/k8sapi.WatcherGroup[...].List(0x4800, {0x23cab20?, 0xc0004ee7c0})
	github.com/datawire/k8sapi@v0.1.2/pkg/k8sapi/watcher_group.go:51 +0x135
github.com/datawire/ambassador-agent/pkg/agent/watchers.(*networkWatcher).List(0xc000360aa0, {0x23cab20?, 0xc0004ee7c0?})
	github.com/datawire/ambassador-agent/pkg/agent/watchers/ingress_watcher.go:115 +0x59
github.com/datawire/ambassador-agent/pkg/agent/watchers.(*FallbackWatchers).LoadSnapshot(0xc00060bbf0, {0x23cab20, 0xc0004ee7c0}, 0xc00729ce80)
	github.com/datawire/ambassador-agent/pkg/agent/watchers/fallback_watchers.go:72 +0x216
github.com/datawire/ambassador-agent/pkg/agent.(*Agent).ProcessSnapshot(0xc0004de6e0, {0x23cab20, 0xc0004ee7c0}, 0xc00729ce80)
	github.com/datawire/ambassador-agent/pkg/agent/agent.go:759 +0x1a7
github.com/datawire/ambassador-agent/pkg/agent.(*Agent).watch(0xc0004de6e0, {0x23cab20, 0xc0004ee7c0}, 0xc000a581e0, 0xc006d70000)
	github.com/datawire/ambassador-agent/pkg/agent/agent.go:542 +0x4f1
github.com/datawire/ambassador-agent/pkg/agent.(*Agent).Watch(0xc0004de6e0, {0x23cab20?, 0xc0004ee7c0})
	github.com/datawire/ambassador-agent/pkg/agent/agent.go:330 +0x1b3
main.main.func2.2({0x23cab20, 0xc0003506c0})
	./main.go:144 +0xc5
created by k8s.io/client-go/tools/leaderelection.(*LeaderElector).Run
	k8s.io/client-go@v0.26.0/tools/leaderelection/leaderelection.go
```

It's actually easy to reproduce that error by adding the following resource to the cluster : 

```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: minimal-ingress
  annotations:
    nginx.ingress.kubernetes.io/rewrite-target: /

spec:
  ingressClassName: nginx-example
  rules:
  - http:
      paths:
      - path: /testpath
        pathType: Prefix
        backend:
          service:
            name: test
            port:
              number: 80
```

I assume we didn't use the right type even and I doubt this ever worked correctly. Since the classic emissary setup doesn't have any vanilla Ingress, we probably missed it.

I've also found a bug (nil pointer) after changing the type, so this PR also packages this fix.

I've tested it in my kubeception cluster, and I don't have the panic anymore. The Ingress is also correctly reported to the cloud (I've checked the DB).

## Fill ALL sections
#### Documentation
- [ ] I updated the relevant .md documentation.
- [ ] I updated the relevant website documentation.
- [x] This PR does not require documentation updates.

#### Dependencies
- [ ] This PR contains new dependencies
- [x] This PR does not have any change in dependencies.

#### Testing
- [x] I provided sufficient test coverage for the modified code.
- [ ] The existing tests capture the requirements for the modified code.
- [x] The bulk of my code covered by unit tests.
- [x] I executed manual tests to validate my changes and to avoid regressions.
 