### PR TITLE
Updated go-mkopensource to fix an issue that could make the dependency information ouf of sync with go.mod

### DIFF
--- a/.github/workflows/licenses.yaml
+++ b/.github/workflows/licenses.yaml
@@ -20,10 +20,10 @@ jobs:
         shell: bash
         run: make generate
       - name: "Save dependency changes if committer is dependabot"
-        uses: datawire/go-mkopensource/actions/save-dependabot-changes@v0.0.1
+        uses: datawire/go-mkopensource/actions/save-dependabot-changes@v0.0.7
         id: changed-by-dependabot
         with:
-          github_token: ${{ secrets.GH_D6EAUTOMATON }}
+          branches_to_skip: master
       - name: "Abort if dependabot triggered a dependency update"
         if: steps.changed-by-dependabot.outputs.is_dirty == 'true'
         run: |

--- a/tools/src/go-mkopensource/go.mod
+++ b/tools/src/go-mkopensource/go.mod
@@ -2,7 +2,7 @@ module local
 
 go 1.18
 
-require github.com/datawire/go-mkopensource v0.0.1
+require github.com/datawire/go-mkopensource v0.0.7
 
 require (
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/tools/src/go-mkopensource/go.sum
+++ b/tools/src/go-mkopensource/go.sum
@@ -1,5 +1,5 @@
-github.com/datawire/go-mkopensource v0.0.1 h1:DKWDoQ8hSzLgYR/s/YPdcyEKcO5GGnDO25PNFDArTCc=
-github.com/datawire/go-mkopensource v0.0.1/go.mod h1:6WIetr8QL8XpzFUjJAb6kA/yQALBOGxUCd10UXEQwyY=
+github.com/datawire/go-mkopensource v0.0.7 h1:tuzUK2oSr7CrfBZWynWxcbTmbrpvGqzR/PuLYXwZHok=
+github.com/datawire/go-mkopensource v0.0.7/go.mod h1:6WIetr8QL8XpzFUjJAb6kA/yQALBOGxUCd10UXEQwyY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=


### PR DESCRIPTION
## Description
go-mkopensource will update go.mod and go.sum if necessary when a dependabot PR fails to build because dependencies are broken.

These updates were being used to generate DEPENDENCIES.md and DEPENDENCY_LICENSES.md, but they were not being saved back into the repo, which would cause a mismatch between license information and contents of go.mod.

This change also removes the need for using a personal access token, which will improve security.

## Fill ALL sections
#### Documentation
- [ ] I updated the relevant .md documentation.
- [ ] I updated the relevant website documentation.
- [x] This PR does not require documentation updates.

#### Dependencies
- [ ] This PR contains new dependencies
- [x] This PR does not have any change in dependencies.

#### Testing
- [ ] I provided sufficient test coverage for the modified code.
- [ ] The existing tests capture the requirements for the modified code.
- [ ] The bulk of my code covered by unit tests.
- [x] I executed manual tests to validate my changes and to avoid regressions.
  
##### Testing Strategy
Tested in a similar saas_app [PR](https://github.com/datawire/saas_app/actions/runs/4164808326/jobs/7206947078).

![image](https://user-images.githubusercontent.com/95947712/218510982-a5f9046e-b622-4b60-8841-b4a01759085f.png)

## Dependencies, related issues, and other notes
N/A